### PR TITLE
I-ALiRT: Query api cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # I-ALiRT Data Access Package
 
-This lightweight  Python package allows users to query log data.
+This lightweight Python package allows users to query log data.
 
 ## Command Line Utility
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,73 @@
-# ialirt-data-access
-Package and command line utility for users to download and query data from I-ALiRT
+# I-ALiRT Data Access Package
+
+This lightweight  Python package allows users to query log data.
+
+## Command Line Utility
+
+### To install
+
+```bash
+pip install ialirt-data-access
+ialirt-data-access -h
+```
+
+### Query / Search for logs
+
+Find all files from a given year, day of year, and instance
+
+```bash
+$ ialirt_data_access --url <url> ialirt-log-query --year <year> --doy <doy> --instance <instance>
+```
+
+## Importing as a package
+
+```python
+import ialirt_data_access
+
+# Search for files
+results = ialirt_data_access.query(year="2024", doy="045", instance="1")
+```
+
+## Configuration
+
+### Data Access URL
+
+To change the default URL that the package accesses, you can set
+the environment variable ``IALIRT_DATA_ACCESS_URL`` or within the
+package ``ialirt_data_access.config["DATA_ACCESS_URL"]``. The default
+is the development server ``https://alirt.dev.imap-mission.com``.
+
+## Troubleshooting
+
+### Network issues
+
+#### SSL
+
+If you encounter SSL errors similar to the following:
+
+```text
+urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:997)>
+```
+
+That generally means the Python environment you're using is not finding your system's root
+certificates properly. This means you need to tell Python how to find those certificates
+with the following potential solutions.
+
+1. **Upgrade the certifi package**
+
+    ```bash
+    pip install --upgrade certifi
+    ```
+
+2. **Install system certificates**
+    Depending on the Python version you installed the program with the command will look something like this:
+
+    ```bash
+    /Applications/Python\ 3.10/Install\ Certificates.command
+    ```
+
+#### HTTP Error 502: Bad Gateway
+
+This could mean that the service is temporarily down. If you
+continue to encounter this, reach out to the IMAP SDC at
+<imap-sdc@lasp.colorado.edu>.

--- a/ialirt_data_access/__init__.py
+++ b/ialirt_data_access/__init__.py
@@ -1,0 +1,24 @@
+"""Data Access for I-ALiRT.
+
+This package contains the data access tools for the I-ALiRT logs. It
+provides a convenient way to query and download log files.
+"""
+
+import os
+
+from ialirt_data_access.io import query
+
+__all__ = [
+    "query",
+]
+__version__ = "0.1.0"
+
+
+config = {
+    "DATA_ACCESS_URL": os.getenv("IALIRT_DATA_ACCESS_URL")
+    or "https://alirt.dev.imap-mission.com",
+}
+"""Settings configuration dictionary.
+
+DATA_ACCESS_URL : This is the URL of the data access API.
+"""

--- a/ialirt_data_access/__init__.py
+++ b/ialirt_data_access/__init__.py
@@ -1,7 +1,7 @@
 """Data Access for I-ALiRT.
 
-This package contains the data access tools for the I-ALiRT logs. It
-provides a convenient way to query and download log files.
+This package contains the data access tools for the I-ALiRT logs.
+Provides a convenient way to query and download log files.
 """
 
 import os

--- a/ialirt_data_access/cli.py
+++ b/ialirt_data_access/cli.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+
+"""Command line interface to query the IALIRT log API.
+
+This module allows querying the IALIRT log API using command-line arguments.
+
+Usage:
+    ialirt-log-query --year <year> --doy <doy> --instance <instance>
+"""
+
+import argparse
+import logging
+
+import ialirt_data_access
+
+
+def _query_parser(args: argparse.Namespace):
+    """Query the IALIRT log API."""
+    # Use the provided URL or the default
+    valid_args = [
+        "year",
+        "doy",
+        "instance",
+    ]
+    query_params = {
+        key: value
+        for key, value in vars(args).items()
+        if key in valid_args and value is not None
+    }
+    try:
+        query_results = ialirt_data_access.query(**query_params)
+        print(query_results)
+    except ialirt_data_access.io.IMAPDataAccessError as e:
+        print(e)
+        return
+
+
+def main():
+    """Parse the command line arguments.
+
+    Run the command line interface to the IALIRT Data Access API.
+    """
+    url_help = (
+        "URL of the IALIRT API. "
+        "The default is https://ialirt.dev.imap-mission.com. This can also be "
+        "set using the IALIRT_DATA_ACCESS_URL environment variable."
+    )
+
+    parser = argparse.ArgumentParser(prog="ialirt-data-access")
+    parser.add_argument("--url", type=str, required=False, help=url_help)
+    # Logging level
+    parser.add_argument(
+        "--debug",
+        help="Print lots of debugging statements",
+        action="store_const",
+        dest="loglevel",
+        const=logging.DEBUG,
+        default=logging.WARNING,
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        help="Add verbose output",
+        action="store_const",
+        dest="loglevel",
+        const=logging.INFO,
+    )
+
+    # Query command
+    subparsers = parser.add_subparsers(required=True)
+    query_parser = subparsers.add_parser("ialirt-log-query")
+
+    query_parser.add_argument(
+        "--year",
+        type=int,
+        required=True,
+        help="Year",
+    )
+
+    query_parser.add_argument(
+        "--doy",
+        type=int,
+        required=True,
+        help="Day of Year",
+    )
+
+    query_parser.add_argument(
+        "--instance",
+        type=int,
+        required=True,
+        help="Instance",
+        choices=[
+            1,
+            2,
+        ],
+    )
+
+    query_parser.set_defaults(func=_query_parser)
+
+    # Parse the arguments and set the values
+    args = parser.parse_args()
+    logging.basicConfig(level=args.loglevel)
+
+    if args.url:
+        # We got an explicit url from the command line
+        ialirt_data_access.config["DATA_ACCESS_URL"] = args.url
+
+    # Now process through the respective function for the invoked command
+    # (set with set_defaults on the subparsers above)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/ialirt_data_access/cli.py
+++ b/ialirt_data_access/cli.py
@@ -6,6 +6,8 @@ This module allows querying the IALIRT log API using command-line arguments.
 
 Usage:
     ialirt-log-query --year <year> --doy <doy> --instance <instance>
+    (venv) MacL4581:ialirt-data-access lasa6858$ python3 ialirt_data_access/cli.py --url https://ialirt.dev.imap-mission.com ialirt-log-query --year 2024 --doy 045 --instance 1
+{'files': ['flight_iois_1.log.2024-045T16-54-46_123456.txt']}
 """
 
 import argparse
@@ -30,7 +32,7 @@ def _query_parser(args: argparse.Namespace):
     try:
         query_results = ialirt_data_access.query(**query_params)
         print(query_results)
-    except ialirt_data_access.io.IMAPDataAccessError as e:
+    except ialirt_data_access.io.IALIRTDataAccessError as e:
         print(e)
         return
 
@@ -72,26 +74,26 @@ def main():
 
     query_parser.add_argument(
         "--year",
-        type=int,
+        type=str,
         required=True,
         help="Year",
     )
 
     query_parser.add_argument(
         "--doy",
-        type=int,
+        type=str,
         required=True,
         help="Day of Year",
     )
 
     query_parser.add_argument(
         "--instance",
-        type=int,
+        type=str,
         required=True,
         help="Instance",
         choices=[
-            1,
-            2,
+            "1",
+            "2",
         ],
     )
 

--- a/ialirt_data_access/cli.py
+++ b/ialirt_data_access/cli.py
@@ -2,12 +2,8 @@
 
 """Command line interface to query the IALIRT log API.
 
-This module allows querying the IALIRT log API using command-line arguments.
-
 Usage:
-    ialirt-log-query --year <year> --doy <doy> --instance <instance>
-    (venv) MacL4581:ialirt-data-access lasa6858$ python3 ialirt_data_access/cli.py --url https://ialirt.dev.imap-mission.com ialirt-log-query --year 2024 --doy 045 --instance 1
-{'files': ['flight_iois_1.log.2024-045T16-54-46_123456.txt']}
+    ialirt_data_access --debug --url <url> ialirt-log-query --year <year> --doy <doy> --instance <instance>
 """
 
 import argparse
@@ -17,17 +13,21 @@ import ialirt_data_access
 
 
 def _query_parser(args: argparse.Namespace):
-    """Query the IALIRT log API."""
-    # Use the provided URL or the default
-    valid_args = [
-        "year",
-        "doy",
-        "instance",
-    ]
+    """Query the IALIRT log API.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        Parsed arguments including year, doy, and instance.
+
+    Returns
+    -------
+    None
+    """
     query_params = {
-        key: value
-        for key, value in vars(args).items()
-        if key in valid_args and value is not None
+        "year": args.year,
+        "doy": args.doy,
+        "instance": args.instance,
     }
     try:
         query_results = ialirt_data_access.query(**query_params)
@@ -49,6 +49,11 @@ def main():
     )
 
     parser = argparse.ArgumentParser(prog="ialirt-data-access")
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {ialirt_data_access.__version__}",
+    )
     parser.add_argument("--url", type=str, required=False, help=url_help)
     # Logging level
     parser.add_argument(
@@ -73,24 +78,18 @@ def main():
     query_parser = subparsers.add_parser("ialirt-log-query")
 
     query_parser.add_argument(
-        "--year",
-        type=str,
-        required=True,
-        help="Year",
+        "--year", type=str, required=True, help="Year of the logs (e.g., 2024)."
     )
 
     query_parser.add_argument(
-        "--doy",
-        type=str,
-        required=True,
-        help="Day of Year",
+        "--doy", type=str, required=True, help="Day of year of the logs (e.g., 045)."
     )
 
     query_parser.add_argument(
         "--instance",
         type=str,
         required=True,
-        help="Instance",
+        help="Instance number (e.g., 1).",
         choices=[
             "1",
             "2",

--- a/ialirt_data_access/cli.py
+++ b/ialirt_data_access/cli.py
@@ -103,11 +103,9 @@ def main():
     logging.basicConfig(level=args.loglevel)
 
     if args.url:
-        # We got an explicit url from the command line
+        # Explicit url from the command line
         ialirt_data_access.config["DATA_ACCESS_URL"] = args.url
 
-    # Now process through the respective function for the invoked command
-    # (set with set_defaults on the subparsers above)
     args.func(args)
 
 

--- a/ialirt_data_access/cli.py
+++ b/ialirt_data_access/cli.py
@@ -12,6 +12,9 @@ import logging
 
 import ialirt_data_access
 
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
 
 def _query_parser(args: argparse.Namespace):
     """Query the IALIRT log API.
@@ -32,8 +35,10 @@ def _query_parser(args: argparse.Namespace):
     }
     try:
         query_results = ialirt_data_access.query(**query_params)
+        logger.info("Query results: %s", query_results)
         print(query_results)
     except ialirt_data_access.io.IALIRTDataAccessError as e:
+        logger.error("An error occurred: %s", e)
         print(e)
         return
 
@@ -58,6 +63,7 @@ def main():
     parser.add_argument("--url", type=str, required=False, help=url_help)
     # Logging level
     parser.add_argument(
+        "--vv",
         "--debug",
         help="Print lots of debugging statements",
         action="store_const",

--- a/ialirt_data_access/cli.py
+++ b/ialirt_data_access/cli.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 
-"""Command line interface to query the IALIRT log API.
+"""Command line interface to query IALIRT logs in the s3 bucket.
 
 Usage:
-    ialirt_data_access --debug --url <url> ialirt-log-query --year <year> --doy <doy> --instance <instance>
+    ialirt_data_access --debug --url <url> ialirt-log-query
+    --year <year> --doy <doy> --instance <instance>
 """
 
 import argparse

--- a/ialirt_data_access/io.py
+++ b/ialirt_data_access/io.py
@@ -2,8 +2,6 @@ import contextlib
 import json
 import logging
 import urllib.request
-from pathlib import Path
-from typing import Optional, Union
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 
@@ -63,11 +61,12 @@ def query(
     list
         List of files matching the query
     """
-    # locals() gives us the keyword arguments passed to the function
-    # and allows us to filter out the None values
-    query_params = {key: value for key, value in locals().items() if value is not None}
-    if not query_params:
-        raise ValueError("Query parameters must be provided")
+    query_params = {
+        "year": year,
+        "doy": doy,
+        "instance": instance,
+    }
+
     url = f"{ialirt_data_access.config['DATA_ACCESS_URL']}"
     url += f"/ialirt-log-query?{urlencode(query_params)}"
 

--- a/ialirt_data_access/io.py
+++ b/ialirt_data_access/io.py
@@ -42,19 +42,20 @@ def _get_url_response(request: urllib.request.Request):
 
 
 def query(
-        year: int,
-        doy: int,
-        instance: int,
+        *,
+        year: str,
+        doy: str,
+        instance: str,
 ):
     """Query the logs.
 
     Parameters
     ----------
-    year : int
+    year : str
         Year
-    doy : int
+    doy : str
         Day of year
-    instance : int
+    instance : str
         Instance number
 
     Returns
@@ -80,4 +81,3 @@ def query(
         items = json.loads(items)
         logger.debug("Decoded JSON: %s", items)
     return items
-

--- a/ialirt_data_access/io.py
+++ b/ialirt_data_access/io.py
@@ -1,0 +1,83 @@
+import contextlib
+import json
+import logging
+import urllib.request
+from pathlib import Path
+from typing import Optional, Union
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+
+import ialirt_data_access
+
+logger = logging.getLogger(__name__)
+
+
+class IALIRTDataAccessError(Exception):
+    """Base class for exceptions in this module."""
+
+    pass
+
+@contextlib.contextmanager
+def _get_url_response(request: urllib.request.Request):
+    """Get the response from a URL request.
+
+    This is a helper function to make it easier to handle
+    the different types of errors that can occur when
+    opening a URL and write out the response body.
+    """
+    try:
+        # Open the URL and yield the response
+        with urllib.request.urlopen(request) as response:
+            yield response
+
+    except HTTPError as e:
+        message = (
+            f"HTTP Error: {e.code} - {e.reason}\n"
+            f"Server Message: {e.read().decode('utf-8')}"
+        )
+        raise IALIRTDataAccessError(message) from e
+    except URLError as e:
+        message = f"URL Error: {e.reason}"
+        raise IALIRTDataAccessError(message) from e
+
+
+def query(
+        year: int,
+        doy: int,
+        instance: int,
+):
+    """Query the logs.
+
+    Parameters
+    ----------
+    year : int
+        Year
+    doy : int
+        Day of year
+    instance : int
+        Instance number
+
+    Returns
+    -------
+    list
+        List of files matching the query
+    """
+    # locals() gives us the keyword arguments passed to the function
+    # and allows us to filter out the None values
+    query_params = {key: value for key, value in locals().items() if value is not None}
+    if not query_params:
+        raise ValueError("Query parameters must be provided")
+    url = f"{ialirt_data_access.config['DATA_ACCESS_URL']}"
+    url += f"/ialirt-log-query?{urlencode(query_params)}"
+
+    logger.info("Querying data archive for %s with url %s", query_params, url)
+    request = urllib.request.Request(url, method="GET")
+    with _get_url_response(request) as response:
+        # Retrieve the response as a list of files
+        items = response.read().decode("utf-8")
+        logger.debug("Received response: %s", items)
+        # Decode the JSON string into a list
+        items = json.loads(items)
+        logger.debug("Decoded JSON: %s", items)
+    return items
+

--- a/ialirt_data_access/io.py
+++ b/ialirt_data_access/io.py
@@ -61,7 +61,7 @@ def _validate_query_params(year: str, doy: str, instance: str):
     """
     if not (year.isdigit() and len(year) == 4):
         raise ValueError("Year must be a 4-digit string (e.g., '2024').")
-    if not (doy.isdigit() and 1 <= int(doy) <= 365):
+    if not (doy.isdigit() and 1 <= int(doy) <= 366):
         raise ValueError("DOY must be a string between '001' and '365'.")
     if instance not in {"1", "2"}:
         raise ValueError("Instance must be '1' or '2'.")

--- a/ialirt_data_access/io.py
+++ b/ialirt_data_access/io.py
@@ -1,3 +1,5 @@
+"""The ``io`` module."""
+
 import contextlib
 import json
 import logging
@@ -41,8 +43,7 @@ def _get_url_response(request: urllib.request.Request):
 
 
 def _validate_query_params(year: str, doy: str, instance: str):
-    """
-    Validate the query parameters for the IALIRT log API.
+    """Validate the query parameters for the IALIRT log API.
 
     Parameters
     ----------
@@ -66,9 +67,7 @@ def _validate_query_params(year: str, doy: str, instance: str):
         raise ValueError("Instance must be '1' or '2'.")
 
 
-def query(
-    *, year: str, doy: str, instance: str
-) -> list[str]:
+def query(*, year: str, doy: str, instance: str) -> list[str]:
     """Query the logs.
 
     Parameters

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,9 @@ classifiers = [
     "Operating System :: MacOS",
 ]
 
+[project.scripts]
+ialirt-data-access = "ialirt_data_access.cli:main"
+
 [project.urls]
 homepage = "https://github.com/IMAP-Science-Operations-Center"
 repository = "https://github.com/IMAP-Science-Operations-Center/ialirt-data-access"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,3 +65,5 @@ lint.ignore = ["D104", "D203", "D213", "D413", "PLR2004"]
 [tool.ruff.lint.per-file-ignores]
 # S101: Use of assert detected
 "tests/*" = ["S101"]
+# S310: Audit URL open for permitted schemes.
+"ialirt_data_access/*" = ["S310"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+"""Global pytest configuration for the package."""
+
+import pytest
+
+import ialirt_data_access
+
+
+@pytest.fixture(autouse=True)
+def _set_global_config(monkeypatch: pytest.fixture):
+    """Set the test url."""
+    monkeypatch.setitem(
+        ialirt_data_access.config, "DATA_ACCESS_URL", "https://alirt.test.com"
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Global pytest configuration for the package."""
+"""Global pytest configuration for package."""
 
 import pytest
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,78 @@
+"""Tests for the ``io`` module."""
+
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import patch
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request
+
+import pytest
+
+import ialirt_data_access
+
+@pytest.fixture()
+def mock_urlopen():
+    """Mock urlopen to return a file-like object.
+
+    Yields
+    ------
+    mock_urlopen : unittest.mock.MagicMock
+        Mock object for ``urlopen``
+    """
+    mock_data = b"Mock file content"
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        mock_response = mock_urlopen.return_value.__enter__.return_value
+        mock_response.read.return_value = mock_data
+        yield mock_urlopen
+
+def _set_mock_data(mock_urlopen: unittest.mock.MagicMock, data: bytes):
+    """Set the data returned by the mock urlopen.
+
+    Parameters
+    ----------
+    mock_urlopen : unittest.mock.MagicMock
+        Mock object for ``urlopen``
+    data : bytes
+        The mock data
+    """
+    mock_response = mock_urlopen.return_value.__enter__.return_value
+    mock_response.read.return_value = data
+
+@pytest.mark.parametrize(
+    "query_params",
+    [
+        {
+            "year": "2024",
+            "doy": "045",
+            "instance": "1",
+        },
+    ],
+)
+def test_query(mock_urlopen: unittest.mock.MagicMock, query_params: list[dict]):
+    """Test a basic call to the Query API.
+
+    Parameters
+    ----------
+    mock_urlopen : unittest.mock.MagicMock
+        Mock object for ``urlopen``
+    query_params : list of dict
+        A list of key/value pairs that set the query parameters
+    """
+    _set_mock_data(mock_urlopen, json.dumps([]).encode("utf-8"))
+    response = ialirt_data_access.query(**query_params)
+    # No data found, and JSON decoding works as expected
+    assert response == list()
+
+    # Should have only been one call to urlopen
+    mock_urlopen.assert_called_once()
+    # Assert that the correct URL was used for the query
+    urlopen_call = mock_urlopen.mock_calls[0].args[0]
+    called_url = urlopen_call.full_url
+    expected_url_encoded = f"https://alirt.test.com/ialirt-log-query?{urlencode(query_params)}"
+    assert called_url == expected_url_encoded

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -76,3 +76,17 @@ def test_query(mock_urlopen: unittest.mock.MagicMock, query_params: list[dict]):
     called_url = urlopen_call.full_url
     expected_url_encoded = f"https://alirt.test.com/ialirt-log-query?{urlencode(query_params)}"
     assert called_url == expected_url_encoded
+
+
+def test_query_bad_params(mock_urlopen: unittest.mock.MagicMock):
+    """Test a call to the Query API that has invalid parameters.
+
+    Parameters
+    ----------
+    mock_urlopen : unittest.mock.MagicMock
+        Mock object for ``urlopen``
+    """
+    with pytest.raises(TypeError, match="got an unexpected"):
+        ialirt_data_access.query(bad_param="test")
+    # Should not have made any calls to urlopen
+    assert mock_urlopen.call_count == 0

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -3,71 +3,58 @@
 from __future__ import annotations
 
 import json
-import os
 import unittest
 from io import BytesIO
-from pathlib import Path
 from unittest.mock import patch
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
-from urllib.request import Request
 
 import pytest
 
 import ialirt_data_access
 
+
 @pytest.fixture()
 def mock_urlopen():
-    """Mock urlopen to return a file-like object.
-
-    Yields
-    ------
-    mock_urlopen : unittest.mock.MagicMock
-        Mock object for ``urlopen``
-    """
+    """Mock urlopen to return a file-like object."""
     mock_data = b"Mock file content"
     with patch("urllib.request.urlopen") as mock_urlopen:
         mock_response = mock_urlopen.return_value.__enter__.return_value
         mock_response.read.return_value = mock_data
         yield mock_urlopen
 
-def _set_mock_data(mock_urlopen: unittest.mock.MagicMock, data: bytes):
-    """Set the data returned by the mock urlopen.
 
-    Parameters
-    ----------
-    mock_urlopen : unittest.mock.MagicMock
-        Mock object for ``urlopen``
-    data : bytes
-        The mock data
-    """
+def _set_mock_data(mock_urlopen: unittest.mock.MagicMock, data: bytes):
+    """Set the data returned by the mock urlopen."""
     mock_response = mock_urlopen.return_value.__enter__.return_value
     mock_response.read.return_value = data
 
-@pytest.mark.parametrize(
-    "query_params",
-    [
-        {
-            "year": "2024",
-            "doy": "045",
-            "instance": "1",
-        },
-    ],
-)
-def test_query(mock_urlopen: unittest.mock.MagicMock, query_params: list[dict]):
-    """Test a basic call to the Query API.
 
-    Parameters
-    ----------
-    mock_urlopen : unittest.mock.MagicMock
-        Mock object for ``urlopen``
-    query_params : list of dict
-        A list of key/value pairs that set the query parameters
-    """
-    _set_mock_data(mock_urlopen, json.dumps([]).encode("utf-8"))
+def test_request_errors(mock_urlopen: unittest.mock.MagicMock):
+    """Test that invalid URLs raise an appropriate HTTPError or URLError."""
+    # Set up the mock to raise an HTTPError
+    mock_urlopen.side_effect = HTTPError(
+        url="http://example.com", code=404, msg="Not Found", hdrs={}, fp=BytesIO()
+    )
+    query_params = {"year": "2024", "doy": "045", "instance": "1"}
+    with pytest.raises(ialirt_data_access.io.IALIRTDataAccessError, match="HTTP Error"):
+        ialirt_data_access.query(**query_params)
+
+    # Set up the mock to raise an URLError
+    mock_urlopen.side_effect = URLError(reason="Not Found")
+    mock_urlopen.side_effect = URLError(reason="Not Found")
+    with pytest.raises(ialirt_data_access.io.IALIRTDataAccessError, match="URL Error"):
+        ialirt_data_access.query(**query_params)
+
+
+def test_query(mock_urlopen: unittest.mock.MagicMock):
+    """Test a basic call to the Query API."""
+    filename = "flight_iois_1.log.2024-045T16-54-46_123456.txt"
+    query_params = {"year": "2024", "doy": "045", "instance": "1"}
+    _set_mock_data(mock_urlopen,
+                   json.dumps([filename]).encode("utf-8"))
     response = ialirt_data_access.query(**query_params)
-    # No data found, and JSON decoding works as expected
-    assert response == list()
+    assert response == ["flight_iois_1.log.2024-045T16-54-46_123456.txt"]
 
     # Should have only been one call to urlopen
     mock_urlopen.assert_called_once()
@@ -79,14 +66,8 @@ def test_query(mock_urlopen: unittest.mock.MagicMock, query_params: list[dict]):
 
 
 def test_query_bad_params(mock_urlopen: unittest.mock.MagicMock):
-    """Test a call to the Query API that has invalid parameters.
-
-    Parameters
-    ----------
-    mock_urlopen : unittest.mock.MagicMock
-        Mock object for ``urlopen``
-    """
-    with pytest.raises(TypeError, match="got an unexpected"):
+    """Test a call to the Query API that has invalid parameters."""
+    with pytest.raises(TypeError, match="got an unexpected keyword argument 'bad_param'"):
         ialirt_data_access.query(bad_param="test")
-    # Should not have made any calls to urlopen
+
     assert mock_urlopen.call_count == 0

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,7 +1,8 @@
 """Tests for the ``io`` module."""
 
 from __future__ import annotations
-
+# eeee
+d
 import json
 import unittest
 from io import BytesIO

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,8 +1,7 @@
 """Tests for the ``io`` module."""
 
 from __future__ import annotations
-# eeee
-d
+
 import json
 import unittest
 from io import BytesIO
@@ -52,8 +51,7 @@ def test_query(mock_urlopen: unittest.mock.MagicMock):
     """Test a basic call to the Query API."""
     filename = "flight_iois_1.log.2024-045T16-54-46_123456.txt"
     query_params = {"year": "2024", "doy": "045", "instance": "1"}
-    _set_mock_data(mock_urlopen,
-                   json.dumps([filename]).encode("utf-8"))
+    _set_mock_data(mock_urlopen, json.dumps([filename]).encode("utf-8"))
     response = ialirt_data_access.query(**query_params)
     assert response == ["flight_iois_1.log.2024-045T16-54-46_123456.txt"]
 
@@ -62,13 +60,17 @@ def test_query(mock_urlopen: unittest.mock.MagicMock):
     # Assert that the correct URL was used for the query
     urlopen_call = mock_urlopen.mock_calls[0].args[0]
     called_url = urlopen_call.full_url
-    expected_url_encoded = f"https://alirt.test.com/ialirt-log-query?{urlencode(query_params)}"
+    expected_url_encoded = (
+        f"https://alirt.test.com/ialirt-log-query?{urlencode(query_params)}"
+    )
     assert called_url == expected_url_encoded
 
 
 def test_query_bad_params(mock_urlopen: unittest.mock.MagicMock):
     """Test a call to the Query API that has invalid parameters."""
-    with pytest.raises(TypeError, match="got an unexpected keyword argument 'bad_param'"):
+    with pytest.raises(
+        TypeError, match="got an unexpected keyword argument 'bad_param'"
+    ):
         ialirt_data_access.query(bad_param="test")
 
     assert mock_urlopen.call_count == 0


### PR DESCRIPTION
# Change Summary

## Overview
As you will see I was heavily influenced by imap-data-access. I will use this cli tool for the following:
1. query log files in s3 (implemented here)
2. download log files in s3 (future)
3. query l0 data from DynamoDB (future)
4. download l0 data from DynamoDB (future)
5. query final data products from DynamoDB (future)
6. download final data products from DynamoDB (future)

## New Files
- cli.py
   - Creates a cli for querying
- io.py
   - Validates input query parameters.
   - Sends secure HTTP requests to the IALIRT log API.
- README
   - Instructions for the package
- __init__.py
   - Configures a default API URL
   - Exports the query function as part of the public API.
   - Package versioning

## Testing
Ran the following and viewed the file from s3:
(venv) MacL4581:ialirt-data-access lasa6858$ python3 ialirt_data_access/cli.py --url https://ialirt.dev.imap-mission.com ialirt-log-query --year 2024 --doy 045 --instance 1
{'files': ['flight_iois_1.log.2024-045T16-54-46_123456.txt']}

- conftest
   - Creates test-specific URL
- test.io.py
   - Tests io.py