### PR TITLE
I-ALiRT - add credentials and make default production

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,36 @@ results = ialirt_data_access.log_query(year="2024", doy="045", instance="1")
 To change the default URL that the package accesses, you can set
 the environment variable ``IALIRT_DATA_ACCESS_URL`` or within the
 package ``ialirt_data_access.config["DATA_ACCESS_URL"]``. The default
-is the development server ``https://ialirt.dev.imap-mission.com``.
+is the production server ``https://ialirt.imap-mission.com``.
+
+
+### Automated use with API Keys
+
+The default for the CLI is to use the public endpoints.
+To access some unreleased data products and quicklooks, you may
+need elevated permissions. To programmatically get that, you need
+an API Key, which can be requested from the SDC team.
+
+To use the API Key you can set environment variables and then use
+the tool as usual. Note that the api endpoints are prefixed with `/api-key`
+to request unreleased data. This will also require an update to the
+data access url. So the following should be used when programatically
+accessing the data.
+
+```bash
+IMAP_API_KEY=<your-api-key> IALIRT_DATA_ACCESS_URL=https://ialirt.imap-mission.com/api-key ialirt-data-access ...
+```
+
+or with CLI flags
+
+```bash
+ialirt-data-access --api-key <your-api-key> --url https://ialirt.imap-mission.com/api-key ...
+```
+
+Example:
+```bash
+ialirt-data-access --api-key <api_key> --url https://ialirt.imap-mission.com/api-key ialirt-db-query --met_start 100
+```
 
 ## Troubleshooting
 

--- a/ialirt_data_access/__init__.py
+++ b/ialirt_data_access/__init__.py
@@ -19,7 +19,7 @@ __version__ = "0.2.0"
 
 config = {
     "DATA_ACCESS_URL": os.getenv("IALIRT_DATA_ACCESS_URL")
-    or "https://ialirt.dev.imap-mission.com",
+    or "https://ialirt.imap-mission.com",
 }
 """Settings configuration dictionary.
 

--- a/ialirt_data_access/cli.py
+++ b/ialirt_data_access/cli.py
@@ -158,7 +158,6 @@ def main():
     api_key_help = (
         "API key to authenticate with the IMAP SDC. "
         "This can also be set using the IMAP_API_KEY environment variable. "
-        "It is only necessary for uploading files."
     )
 
     parser = argparse.ArgumentParser(prog="ialirt-data-access")

--- a/ialirt_data_access/cli.py
+++ b/ialirt_data_access/cli.py
@@ -155,8 +155,14 @@ def main():
         "The default is https://ialirt.dev.imap-mission.com. This can also be "
         "set using the IALIRT_DATA_ACCESS_URL environment variable."
     )
+    api_key_help = (
+        "API key to authenticate with the IMAP SDC. "
+        "This can also be set using the IMAP_API_KEY environment variable. "
+        "It is only necessary for uploading files."
+    )
 
     parser = argparse.ArgumentParser(prog="ialirt-data-access")
+    parser.add_argument("--api-key", type=str, required=False, help=api_key_help)
     parser.add_argument(
         "--version",
         action="version",
@@ -288,6 +294,10 @@ def main():
     if args.url:
         # Explicit url from the command line
         ialirt_data_access.config["DATA_ACCESS_URL"] = args.url
+
+    if args.api_key:
+        # We got an explicit api key from the command line
+        ialirt_data_access.config["API_KEY"] = args.api_key
 
     args.func(args)
 

--- a/ialirt_data_access/io.py
+++ b/ialirt_data_access/io.py
@@ -28,6 +28,10 @@ def _get_url_response(request: urllib.request.Request):
     the different types of errors that can occur when
     opening a URL and write out the response body.
     """
+    api_key = ialirt_data_access.config.get("API_KEY")
+    if api_key:
+        request.headers["x-api-key"] = api_key
+
     try:
         # Open the URL and yield the response
         with urllib.request.urlopen(request) as response:


### PR DESCRIPTION
# Change Summary

## Overview
Add credentials and make default production

## Updated Files
- cli.py
Add api key argument
   - Store api key if provided
- io.py
   - Looks for the key and attaches it to the header
- README
   - Update with api key instructions and make default prod
- __init__.py
   - Make default prod