### PR TITLE
I-ALiRT - bugfix and new version

### DIFF
--- a/ialirt_data_access/__init__.py
+++ b/ialirt_data_access/__init__.py
@@ -21,7 +21,7 @@ __all__ = [
     "log_query",
     "packet_query",
 ]
-__version__ = "0.9.0"
+__version__ = "0.10.0"
 
 
 config = {

--- a/ialirt_data_access/io.py
+++ b/ialirt_data_access/io.py
@@ -235,7 +235,7 @@ def download(
         downloads_dir = Path.home() / "Downloads" / filetype
 
     url = f"{ialirt_data_access.config['DATA_ACCESS_URL']}"
-    url += f"/ialirt-download/{filetype}/{filename}"
+    url += f"/api-key/ialirt-download/{filetype}/{filename}"
 
     downloads_dir.mkdir(parents=True, exist_ok=True)
     destination = downloads_dir / filename

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "ialirt-data-access"
-version = "0.9.0"
+version = "0.10.0"
 description = "I-ALiRT Data Access"
 authors = ["IMAP SDC Developers <imap-sdc@lists.lasp.colorado.edu>"]
 readme = "README.md"

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -158,7 +158,7 @@ def test_download(mock_urlopen: unittest.mock.MagicMock, tmp_path: Path):
     mock_urlopen.assert_called_once()
     urlopen_call = mock_urlopen.mock_calls[0].args[0]
     called_url = urlopen_call.full_url
-    expected_url = f"https://ialirt.test.com/ialirt-download/logs/{filename}"
+    expected_url = f"https://ialirt.test.com/api-key/ialirt-download/logs/{filename}"
     assert called_url == expected_url
     assert urlopen_call.method == "GET"
 


### PR DESCRIPTION
# Change Summary

## Overview

This doesn't work until I update the url to include a api-key:

import sys
sys.path.insert(0, ".")
import ialirt_data_access as ida
ida.config["API_KEY"] = "<API Key>"
results = ida.log_query(year="2026", doy="91", instance="1")
filename = results["files"][0]
print(f"Downloading: {filename}")
path = ida.download(
    filetype="logs",
    filename=filename,
    downloads_dir=None
)
print(f"Downloaded to: {path}")