### PR TITLE
bugfix 2

### DIFF
--- a/ialirt_data_access/io.py
+++ b/ialirt_data_access/io.py
@@ -235,7 +235,12 @@ def download(
         downloads_dir = Path.home() / "Downloads" / filetype
 
     url = f"{ialirt_data_access.config['DATA_ACCESS_URL']}"
-    url += f"/api-key/ialirt-download/{filetype}/{filename}"
+
+    # logs and packets route through the API key authorizer; archive is public
+    if filetype in ("logs", "packets"):
+        url += f"/api-key/ialirt-download/{filetype}/{filename}"
+    else:
+        url += f"/ialirt-download/{filetype}/{filename}"
 
     downloads_dir.mkdir(parents=True, exist_ok=True)
     destination = downloads_dir / filename


### PR DESCRIPTION
This pull request updates the URL construction logic in the `download` function to ensure that downloads for certain file types are routed correctly through the API key authorizer, while others use a public route.

Download URL routing changes:

* In `ialirt_data_access/io.py`, the `download` function now routes downloads for `logs` and `packets` file types through the `/api-key/ialirt-download/` endpoint, while other file types use the `/ialirt-download/` public endpoint.